### PR TITLE
Add tests for EmploymentFormService

### DIFF
--- a/src/test/java/org/example/cyberwatch/features/form/service/EmploymentFormServiceTest.java
+++ b/src/test/java/org/example/cyberwatch/features/form/service/EmploymentFormServiceTest.java
@@ -3,6 +3,7 @@ package org.example.cyberwatch.features.form.service;
 import org.example.cyberwatch.features.form.dto.CreateEmploymentDTO;
 import org.example.cyberwatch.features.form.dto.EmploymentFormDTO;
 import org.example.cyberwatch.features.form.dto.UpdateEmploymentDTO;
+import org.example.cyberwatch.features.form.exception.EmploymentFormNotFound;
 import org.example.cyberwatch.features.form.mapper.EmploymentMapper;
 import org.example.cyberwatch.features.form.model.EmploymentForm;
 import org.example.cyberwatch.features.form.repository.EmploymentFormRepository;
@@ -76,9 +77,8 @@ class EmploymentFormServiceTest {
     }
 
     @Test
-    @DisplayName("Should throw exception if another HR tries to update the form")
-    void updateForm_UnauthorizedUser_ThrowsException() {
-        // Arrange
+    @DisplayName("Should throw exception if logged in user does not exist")
+    void updateForm_UserNotFound_ThrowsException() {
         Long formId = 1L;
         UpdateEmploymentDTO updateDto = new UpdateEmploymentDTO();
 
@@ -90,11 +90,37 @@ class EmploymentFormServiceTest {
         existingForm.setStatus(ApprovalStatus.PENDING);
 
         when(formRepository.findById(formId)).thenReturn(Optional.of(existingForm));
+        when(staffRepository.findByEmail("hacker@cyberwatch.local")).thenReturn(Optional.empty());
 
-        // Act & Assert
-        assertThrows(StaffNotFoundException.class, () -> {
-            service.updateFormBeforeApproval(formId, updateDto, "hacker@cyberwatch.local");
-        });
+        assertThrows(StaffNotFoundException.class, () ->
+                service.updateFormBeforeApproval(formId, updateDto, "hacker@cyberwatch.local")
+        );
+    }
+
+
+    @Test
+    @DisplayName("Should throw exception if user is not creator or admin")
+    void updateForm_UnauthorizedUser_ThrowsException() {
+        Long formId = 1L;
+        UpdateEmploymentDTO updateDto = new UpdateEmploymentDTO();
+
+        Staff creator = new Staff();
+        creator.setEmail("owner@cyberwatch.local");
+
+        Staff otherHr = new Staff();
+        otherHr.setEmail("other@cyberwatch.local");
+        otherHr.setRole(Role.HR); // inte admin, inte creator
+
+        EmploymentForm existingForm = new EmploymentForm();
+        existingForm.setCreatedBy(creator);
+        existingForm.setStatus(ApprovalStatus.PENDING);
+
+        when(formRepository.findById(formId)).thenReturn(Optional.of(existingForm));
+        when(staffRepository.findByEmail("other@cyberwatch.local")).thenReturn(Optional.of(otherHr));
+
+        assertThrows(IllegalStateException.class, () ->
+                service.updateFormBeforeApproval(formId, updateDto, "other@cyberwatch.local")
+        );
     }
 
     @Test
@@ -148,5 +174,137 @@ class EmploymentFormServiceTest {
         assertEquals(ApprovalStatus.APPROVED, form.getStatus());
         verify(s3Service).uploadJsonData(anyString(), anyString());
         verify(staffRepository).save(newEmployee);
+    }
+
+    @Test
+    @DisplayName("Should throw exception if SSN already exists in form repository")
+    void createForm_DuplicateSsnInForms_ThrowsException() {
+        //arrange
+        CreateEmploymentDTO dto = new CreateEmploymentDTO(
+                "19900101-1234", "Alice", "Andersson",
+                "alice@test.com", "070", Role.HR, Department.BACKEND, null, null, null
+        );
+
+        //act
+        when(formRepository.existsBySocialSecurityNumber("19900101-1234")).thenReturn(true);
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.createForm(dto, "hr@cyberwatch.local")
+        );
+        verify(formRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw exception if SSN already exists in staff repository")
+    void createForm_DuplicateSsnInStaff_ThrowsException() {
+        //arrange
+        CreateEmploymentDTO dto = new CreateEmploymentDTO(
+                "19900101-1234", "Alice", "Andersson",
+                "alice@test.com", "070", Role.HR, Department.BACKEND, null, null, null
+        );
+
+        //act
+        when(formRepository.existsBySocialSecurityNumber("19900101-1234")).thenReturn(false);
+        when(staffRepository.existsBySocialSecurityNumber("19900101-1234")).thenReturn(true);
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.createForm(dto, "hr@cyberwatch.local")
+        );
+        verify(formRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw exception if form is not PENDING when updating")
+    void updateForm_NotPendingStatus_ThrowsException() {
+        //arrange
+        Long formId = 1L;
+        UpdateEmploymentDTO updateDto = new UpdateEmploymentDTO();
+        EmploymentForm existingForm = new EmploymentForm();
+        existingForm.setStatus(ApprovalStatus.APPROVED);
+
+        //act
+        when(formRepository.findById(formId)).thenReturn(Optional.of(existingForm));
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.updateFormBeforeApproval(formId, updateDto, "hr@cyberwatch.local")
+        );
+        verify(formRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw exception if form is not PENDING when rejecting")
+    void rejectForm_NotPendingStatus_ThrowsException() {
+        //arrange
+        Long formId = 1L;
+        EmploymentForm form = new EmploymentForm();
+        form.setStatus(ApprovalStatus.APPROVED);
+
+        //act
+        when(formRepository.findById(formId)).thenReturn(Optional.of(form));
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.rejectForm(formId, "cto@cyberwatch.local")
+        );
+        verify(formRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw exception if form not found")
+    void rejectForm_FormNotFound_ThrowsException() {
+        //act
+        when(formRepository.findById(99L)).thenReturn(Optional.empty());
+
+        //assert
+        assertThrows(EmploymentFormNotFound.class, () ->
+                service.rejectForm(99L, "cto@cyberwatch.local")
+        );
+    }
+
+    @Test
+    @DisplayName("Should throw exception if form is not PENDING when approving")
+    void approveAndFinalize_NotPendingStatus_ThrowsException() {
+        //arrange
+        Long formId = 1L;
+        EmploymentForm form = new EmploymentForm();
+        form.setStatus(ApprovalStatus.APPROVED);
+
+        Staff cto = new Staff();
+        cto.setRole(Role.CTO);
+
+        //act
+        when(formRepository.findById(formId)).thenReturn(Optional.of(form));
+        when(staffRepository.findByEmail("cto@cyberwatch.local")).thenReturn(Optional.of(cto));
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.approveAndFinalizeEmployment(formId, "cto@cyberwatch.local")
+        );
+        verify(staffRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw exception if approver is not CEO or CTO")
+    void approveAndFinalize_WrongRole_ThrowsException() {
+        //arrange
+        Long formId = 1L;
+        EmploymentForm form = new EmploymentForm();
+        form.setStatus(ApprovalStatus.PENDING);
+
+        Staff hr = new Staff();
+        hr.setRole(Role.HR);
+
+        //act
+        when(formRepository.findById(formId)).thenReturn(Optional.of(form));
+        when(staffRepository.findByEmail("hr@cyberwatch.local")).thenReturn(Optional.of(hr));
+
+        //assert
+        assertThrows(IllegalStateException.class, () ->
+                service.approveAndFinalizeEmployment(formId, "hr@cyberwatch.local")
+        );
+        verify(staffRepository, never()).save(any());
     }
 }

--- a/src/test/java/org/example/cyberwatch/features/form/service/EmploymentFormServiceTest.java
+++ b/src/test/java/org/example/cyberwatch/features/form/service/EmploymentFormServiceTest.java
@@ -95,6 +95,7 @@ class EmploymentFormServiceTest {
         assertThrows(StaffNotFoundException.class, () ->
                 service.updateFormBeforeApproval(formId, updateDto, "hacker@cyberwatch.local")
         );
+        verify(formRepository, never()).save(any());
     }
 
 
@@ -121,6 +122,7 @@ class EmploymentFormServiceTest {
         assertThrows(IllegalStateException.class, () ->
                 service.updateFormBeforeApproval(formId, updateDto, "other@cyberwatch.local")
         );
+        verify(formRepository, never()).save(any());
     }
 
     @Test
@@ -255,10 +257,6 @@ class EmploymentFormServiceTest {
     @Test
     @DisplayName("Should throw exception if form not found")
     void rejectForm_FormNotFound_ThrowsException() {
-        //act
-        when(formRepository.findById(99L)).thenReturn(Optional.empty());
-
-        //assert
         assertThrows(EmploymentFormNotFound.class, () ->
                 service.rejectForm(99L, "cto@cyberwatch.local")
         );


### PR DESCRIPTION
This pull request adds several new unit tests to the `EmploymentFormServiceTest` class, focusing on validating error handling and edge cases for the employment form service. The tests cover scenarios such as duplicate SSNs, invalid form status transitions, missing users or forms, and unauthorized actions. These additions help ensure the robustness of the service by verifying that appropriate exceptions are thrown in various failure cases.

**Error handling for form creation and updates:**
* Added tests to ensure that creating a form with a duplicate SSN in either the forms or staff repository throws an `IllegalStateException` and does not attempt to save the form.
* Added tests to verify that updating or rejecting a form that is not in the `PENDING` status throws an `IllegalStateException` and does not save changes.

**Authorization and existence checks:**
* Added tests to ensure that updating a form with a non-existent user throws a `StaffNotFoundException`, and that users who are not the creator or an admin receive an `IllegalStateException`.
* Added a test to verify that rejecting a non-existent form throws an `EmploymentFormNotFound` exception.

**Approval process validation:**
* Added tests to ensure that only users with the `CEO` or `CTO` role can approve and finalize employment forms, and that the form must be in the `PENDING` status for approval.

**Test imports:**
* Imported the `EmploymentFormNotFound` exception to support the new test cases.…duplicate SSNs, and check form status before updates and approvals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for employment form service error handling and validation scenarios, including authorization checks, duplicate identification validation, status validation, and role-based approval restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->